### PR TITLE
Provide unique key for ExtensionMessagesFiles

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -53,7 +53,7 @@
 	},
 
 	"ExtensionMessagesFiles": {
-		"NetworkParserFunction": "i18n/_MagicWords.php"
+		"ExternalContentMagic": "i18n/_MagicWords.php"
 	},
 
 	"AutoloadNamespaces": {


### PR DESCRIPTION
Fixes issue
  Error: invalid magic word 'embed' 

when you also use the Network extension.

See https://codesearch.wmcloud.org/search/?q=NetworkParserFunction#ProfessionalWiki/Network

and https://github.com/wikimedia/mediawiki/blob/master/docs/config-schema.yaml#L7014C23-L7015C88